### PR TITLE
Error handling

### DIFF
--- a/examples/basic/error_handling.browse
+++ b/examples/basic/error_handling.browse
@@ -1,0 +1,6 @@
+rule test { throw error }
+
+match (test? x) {
+  Err e { print "Error:" $e }
+  Ok v { print "Ok:" $v }
+}

--- a/examples/web/windsor.browse
+++ b/examples/web/windsor.browse
@@ -4,11 +4,12 @@
 set headless false
 
 page https://windsor.io {
-  click input # TODO: catch and ignore any errors from this
+  click? input
   wait 2000
   click input
   type test@windsor.io
   click `.signup-button`
+  wait 5000
 }
 
 visit https://windsor.io

--- a/packages/core/lib/index.js
+++ b/packages/core/lib/index.js
@@ -119,9 +119,10 @@ const evalExpr = async (expr, scope) => {
  */
 const evalRule = async (rule, scope) => {
   const { fn, args } = rule;
+  const { name: ruleWord, options, optional, source } = fn;
 
   const resolvedOpts = {};
-  for (const opt of fn.options) {
+  for (const opt of options) {
     if (resolvedOpts[opt.key.name] !== undefined) {
       throw new BrowseError({
         message: `Option '${opt.key.name}' has already been provided to this rule`,
@@ -139,7 +140,7 @@ const evalRule = async (rule, scope) => {
     }
   }
   try {
-    if (fn.name.name === "import") {
+    if (ruleWord.name === "import") {
       const fname = path.basename(resolvedArgs[0]);
       let to = fname.split(".")[0];
       if (resolvedArgs.length === 3) {
@@ -150,7 +151,7 @@ const evalRule = async (rule, scope) => {
 
       if (/^[\.\/]/.test(resolvedArgs[0]))
         scope.modules[to] = await loadModule(
-          path.resolve(fn.source.basedir, resolvedArgs[0]),
+          path.resolve(source.basedir, resolvedArgs[0]),
           { library: false }
         );
       else
@@ -158,18 +159,24 @@ const evalRule = async (rule, scope) => {
           library: true,
         });
 
-      return null;
+      return optional ? { __type__: "Ok", [0]: null } : null;
     } else {
       // It's possible for the fn call itself to throw in the case that it's not
-      // async This try...catch will handle that, and also any errors from a
+      // async The try...catch will handle that, and also any errors from a
       // rejected promise
       const promise = Promise.resolve(
         resolveRule(fn, scope)(scope)(resolvedOpts)(...resolvedArgs)
       );
-      return await promise.then((v) => (v === undefined ? null : v));
+      const retVal = await promise.then((v) => (v === undefined ? null : v));
+      return optional ? { __type__: "Ok", [0]: retVal } : retVal;
     }
   } catch (err) {
-    throw BrowseError.from(err, fn.name);
+    const errWithStackTrace = BrowseError.from(err, ruleWord);
+    if (optional) {
+      return { __type__: "Err", [0]: errWithStackTrace };
+    } else {
+      throw errWithStackTrace;
+    }
   }
 };
 

--- a/packages/core/lib/index.js
+++ b/packages/core/lib/index.js
@@ -159,7 +159,9 @@ const evalRule = async (rule, scope) => {
           library: true,
         });
 
-      return optional ? { __type__: "Ok", [0]: null } : null;
+      return optional
+        ? new Map(Object.entries({ __type__: "Ok", [0]: null }))
+        : null;
     } else {
       // It's possible for the fn call itself to throw in the case that it's not
       // async The try...catch will handle that, and also any errors from a
@@ -168,12 +170,16 @@ const evalRule = async (rule, scope) => {
         resolveRule(fn, scope)(scope)(resolvedOpts)(...resolvedArgs)
       );
       const retVal = await promise.then((v) => (v === undefined ? null : v));
-      return optional ? { __type__: "Ok", [0]: retVal } : retVal;
+      return optional
+        ? new Map(Object.entries({ __type__: "Ok", [0]: retVal }))
+        : retVal;
     }
   } catch (err) {
     const errWithStackTrace = BrowseError.from(err, ruleWord);
     if (optional) {
-      return { __type__: "Err", [0]: errWithStackTrace };
+      return new Map(
+        Object.entries({ __type__: "Err", [0]: errWithStackTrace })
+      );
     } else {
       throw errWithStackTrace;
     }

--- a/packages/core/lib/scope.js
+++ b/packages/core/lib/scope.js
@@ -122,7 +122,7 @@ const resolveVarScope = (name, scope) => {
  * @param {Scope} scope The scope to use
  * @param {any => boolean} predicate An optional predicate with which to test the resolved value
  */
-const resolveInternal = (name, scope, predicate = () => true) => {
+const resolveInternal = (name, scope, predicate = (_) => true) => {
   if (!scope) {
     throw new Error(`Internal:: Internal Variable '${name}' is not defined`);
   }

--- a/packages/parser/lib/browse.ohm
+++ b/packages/parser/lib/browse.ohm
@@ -56,7 +56,7 @@ Browse {
 
   wordStart = letter | "_" | "@"
             | "\\" unicodeEscapeSequence -- escaped
-  wordPart = wordStart | "?"  | "$"
+  wordPart = wordStart | "$"
             | unicodeCombiningMark | unicodeDigit
             | unicodeConnectorPunctuation
             | "\u200C" | "\u200D"
@@ -195,6 +195,13 @@ Browse {
     = OrExpr "||" noop AndExpr -- or
     | AndExpr
 
+  InvalidBinExpr
+    = InvalidBinExpr "&" noop OrExpr -- and
+    | InvalidBinExpr "^" noop OrExpr -- xor
+    // We can't do 'or' because `|` starts a string literal atm
+    // | InvalidBinExpr "|" noop OrExpr -- or
+    | OrExpr
+
   Expr (an expression)
     = OrExpr
   
@@ -209,12 +216,15 @@ Browse {
 
   Options = (lineTerminator* Option)+ lineTerminator*
 
-
   ruleName = (word ":")? word
 
+  errorRule
+          = ruleName "?"    -- optional
+          | ruleName        -- vanilla
+
   InitRule
-  	= #(ruleName "(") Options ")"   -- withOpts
-    | ruleName                      -- vanilla
+  	= #(errorRule "(") Options ")"   -- withOpts
+    | errorRule                      -- vanilla
     
 
   Rule

--- a/packages/web/lib/page.js
+++ b/packages/web/lib/page.js
@@ -59,15 +59,16 @@ const getPageScope = (parent) => {
       if (value === null || value === undefined) {
         value = null; // We don't want undefined in the `finally` clause
         throw new Error(
-          `Element given to @${type} call had no content of the correct type. If this value is optional, try using @${type}?. This will set the value to null if a match isn't found`
+          `Element given to @${type} call had no content of the correct type`
         );
       }
       if (trim && typeof value === "string") {
         value = value.trim();
       }
     } catch (e) {
-      if (!optional) throw e;
+      throw e;
     } finally {
+      // Always explicitly set it to null
       pageScope.vars[key] = value;
     }
     return value;
@@ -88,16 +89,10 @@ const getPageScope = (parent) => {
             "Takes in a selector and clicks the argument indicated by the selector",
           "@string":
             "<key> <selector>: Sets a key on the data object in nearest page scope to a string value specified by selector",
-          "@string?":
-            "<key> <selector>: Sets a key on the data object in nearest page scope to a string value specified by selector or null if there is no string value",
           "@number":
             "<key> <selector>: Sets a key on the data object in nearest page scope to a numeric value specified by selector",
-          "@number?":
-            "<key> <selector>: Sets a key on the data object in nearest page scope to a numeric value specified by selector or null if there is no numeric value",
           "@url":
             "<key> <selector>: Sets a key on the data object in nearest page scope to the href value at the selector",
-          "@url?":
-            "<key> <selector>: Sets a key on the data object in nearest page scope to the href value at the selector or to null if there is no href value",
           page:
             "Defines a page definition which matches on the regex passed in as the first argument, and which executes the rule set passed in as the second argument on every matching page",
           press: "Presses the given key",
@@ -129,11 +124,8 @@ const getPageScope = (parent) => {
       return pageScope.internal.config;
     },
     "@string": dataExtractionRule(getString, "string"),
-    "@string?": dataExtractionRule(getString, "string", true),
     "@number": dataExtractionRule(getNumber, "number"),
-    "@number?": dataExtractionRule(getNumber, "number", true),
     "@url": dataExtractionRule(getUrl, "url"),
-    "@url?": dataExtractionRule(getUrl, "url", true),
     "@arr": (_) => ({ string = false, trim = true }) => async (
       key,
       selector


### PR DESCRIPTION
Added the optional ('?') syntax and simple pattern matching and throw rules for basic error handling

```
rule test { throw error }

match (test? x) {
  Err e { print "Error:" $e }
  Ok v { print "Ok:" $v }
}
```